### PR TITLE
Feature/use configurable module builder

### DIFF
--- a/packages/nestjs-access-control/src/access-control.module-definition.ts
+++ b/packages/nestjs-access-control/src/access-control.module-definition.ts
@@ -66,8 +66,8 @@ export function createAccessControlImports(
   }
 }
 
-export function createAccessControlExports(): string[] {
-  return [ACCESS_CONTROL_MODULE_SETTINGS_TOKEN];
+export function createAccessControlExports() {
+  return [ACCESS_CONTROL_MODULE_SETTINGS_TOKEN, AccessControlService];
 }
 
 export function createAccessControlProviders(overrides: {
@@ -76,6 +76,7 @@ export function createAccessControlProviders(overrides: {
 }): Provider[] {
   return [
     ...(overrides.providers ?? []),
+    AccessControlService,
     createAccessControlSettingsProvider(overrides.options),
     createAccessControlServiceProvider(overrides.options),
   ];

--- a/packages/nestjs-access-control/src/access-control.module-definition.ts
+++ b/packages/nestjs-access-control/src/access-control.module-definition.ts
@@ -76,7 +76,6 @@ export function createAccessControlProviders(overrides: {
 }): Provider[] {
   return [
     ...(overrides.providers ?? []),
-    AccessControlService,
     createAccessControlSettingsProvider(overrides.options),
     createAccessControlServiceProvider(overrides.options),
   ];

--- a/packages/nestjs-access-control/src/access-control.module.ts
+++ b/packages/nestjs-access-control/src/access-control.module.ts
@@ -1,5 +1,4 @@
 import { DynamicModule, Module } from '@nestjs/common';
-import { AccessControlService } from './services/access-control.service';
 import {
   AccessControlAsyncOptions,
   AccessControlModuleClass,
@@ -9,10 +8,7 @@ import {
   createAccessControlProviders,
 } from './access-control.module-definition';
 
-@Module({
-  providers: [AccessControlService],
-  exports: [AccessControlService],
-})
+@Module({})
 export class AccessControlModule extends AccessControlModuleClass {
   static register(options: AccessControlOptions): DynamicModule {
     return super.register(options);

--- a/packages/nestjs-auth-github/src/auth-github.module-definition.ts
+++ b/packages/nestjs-auth-github/src/auth-github.module-definition.ts
@@ -22,6 +22,7 @@ import { AuthGithubOptionsExtrasInterface } from './interfaces/auth-github-optio
 import { authGithubDefaultConfig } from './config/auth-github-default.config';
 import { AuthGithubSettingsInterface } from './interfaces/auth-github-settings.interface';
 import { AuthGithubController } from './auth-github.controller';
+import { AuthGithubStrategy } from './auth-github.strategy';
 
 const RAW_OPTIONS_TOKEN = Symbol('__AUTH_GITHUB_MODULE_RAW_OPTIONS_TOKEN__');
 
@@ -66,7 +67,7 @@ export function createAuthGithubImports(): DynamicModule['imports'] {
   return [ConfigModule.forFeature(authGithubDefaultConfig)];
 }
 
-export function createAuthGithubExports(): string[] {
+export function createAuthGithubExports() {
   return [
     AUTH_GITHUB_MODULE_SETTINGS_TOKEN,
     AUTH_GITHUB_ISSUE_TOKEN_SERVICE_TOKEN,
@@ -87,6 +88,7 @@ export function createAuthGithubProviders(options: {
 }): Provider[] {
   return [
     ...(options.providers ?? []),
+    AuthGithubStrategy,
     IssueTokenService,
     FederatedOAuthService,
     createAuthGithubOptionsProvider(options.overrides),

--- a/packages/nestjs-auth-github/src/auth-github.module.ts
+++ b/packages/nestjs-auth-github/src/auth-github.module.ts
@@ -1,8 +1,5 @@
 import { DynamicModule, Module } from '@nestjs/common';
-import { FederatedOAuthService } from '@concepta/nestjs-federated';
 
-import { AuthGithubStrategy } from './auth-github.strategy';
-import { AuthGithubController } from './auth-github.controller';
 import {
   AuthGithubAsyncOptions,
   AuthGithubModuleClass,
@@ -16,10 +13,7 @@ import {
 /**
  * Auth GitHub module
  */
-@Module({
-  providers: [AuthGithubStrategy, FederatedOAuthService],
-  controllers: [AuthGithubController],
-})
+@Module({})
 export class AuthGithubModule extends AuthGithubModuleClass {
   static register(options: AuthGithubOptions): DynamicModule {
     return super.register(options);

--- a/packages/nestjs-auth-jwt/src/auth-jwt.module-definition.ts
+++ b/packages/nestjs-auth-jwt/src/auth-jwt.module-definition.ts
@@ -21,6 +21,7 @@ import {
   AUTH_JWT_MODULE_VERIFY_TOKEN_SERVICE_TOKEN,
 } from './auth-jwt.constants';
 import { authJwtDefaultConfig } from './config/auth-jwt-default.config';
+import { AuthJwtStrategy } from './auth-jwt.strategy';
 
 const RAW_OPTIONS_TOKEN = Symbol('__AUTH_JWT_MODULE_RAW_OPTIONS_TOKEN__');
 
@@ -64,11 +65,12 @@ export function createAuthJwtImports(): DynamicModule['imports'] {
   return [ConfigModule.forFeature(authJwtDefaultConfig)];
 }
 
-export function createAuthJwtExports(): string[] {
+export function createAuthJwtExports() {
   return [
     AUTH_JWT_MODULE_SETTINGS_TOKEN,
     AUTH_JWT_MODULE_USER_LOOKUP_SERVICE_TOKEN,
     AUTH_JWT_MODULE_VERIFY_TOKEN_SERVICE_TOKEN,
+    AuthJwtStrategy,
   ];
 }
 
@@ -78,6 +80,7 @@ export function createAuthJwtProviders(options: {
 }): Provider[] {
   return [
     ...(options.providers ?? []),
+    AuthJwtStrategy,
     VerifyTokenService,
     createAuthJwtOptionsProvider(options.overrides),
     createAuthJwtVerifyTokenServiceProvider(options.overrides),

--- a/packages/nestjs-auth-jwt/src/auth-jwt.module.ts
+++ b/packages/nestjs-auth-jwt/src/auth-jwt.module.ts
@@ -15,10 +15,7 @@ import { AuthJwtStrategy } from './auth-jwt.strategy';
 /**
  * Auth local module
  */
-@Module({
-  providers: [AuthJwtStrategy, VerifyTokenService],
-  exports: [AuthJwtStrategy],
-})
+@Module({})
 export class AuthJwtModule extends AuthJwtModuleClass {
   static register(options: AuthJwtOptions): DynamicModule {
     return super.register(options);

--- a/packages/nestjs-auth-local/src/auth-local.module-definition.ts
+++ b/packages/nestjs-auth-local/src/auth-local.module-definition.ts
@@ -23,6 +23,7 @@ import { AuthLocalOptionsInterface } from './interfaces/auth-local-options.inter
 import { AuthLocalSettingsInterface } from './interfaces/auth-local-settings.interface';
 import { authLocalDefaultConfig } from './config/auth-local-default.config';
 import { AuthLocalController } from './auth-local.controller';
+import { AuthLocalStrategy } from './auth-local.strategy';
 
 const RAW_OPTIONS_TOKEN = Symbol('__AUTH_LOCAL_MODULE_RAW_OPTIONS_TOKEN__');
 
@@ -83,6 +84,7 @@ export function createAuthLocalProviders(options: {
     ...(options.providers ?? []),
     IssueTokenService,
     PasswordStorageService,
+    AuthLocalStrategy,
     createAuthLocalOptionsProvider(options.overrides),
     createAuthLocalIssueTokenServiceProvider(options.overrides),
     createAuthLocalUserLookupServiceProvider(options.overrides),

--- a/packages/nestjs-auth-local/src/auth-local.module.ts
+++ b/packages/nestjs-auth-local/src/auth-local.module.ts
@@ -1,6 +1,4 @@
 import { DynamicModule, Module } from '@nestjs/common';
-import { AuthLocalStrategy } from './auth-local.strategy';
-import { AuthLocalController } from './auth-local.controller';
 import {
   AuthLocalAsyncOptions,
   AuthLocalModuleClass,
@@ -14,10 +12,7 @@ import {
 /**
  * Auth local module
  */
-@Module({
-  providers: [AuthLocalStrategy],
-  controllers: [AuthLocalController],
-})
+@Module({})
 export class AuthLocalModule extends AuthLocalModuleClass {
   static register(options: AuthLocalOptions): DynamicModule {
     return super.register(options);

--- a/packages/nestjs-auth-recovery/src/auth-recovery.module-definition.ts
+++ b/packages/nestjs-auth-recovery/src/auth-recovery.module-definition.ts
@@ -24,6 +24,8 @@ import { AuthRecoveryOptionsExtrasInterface } from './interfaces/auth-recovery-o
 import { AuthRecoverySettingsInterface } from './interfaces/auth-recovery-settings.interface';
 import { authRecoveryDefaultConfig } from './config/auth-recovery-default.config';
 import { AuthRecoveryController } from './auth-recovery.controller';
+import { AuthRecoveryService } from './services/auth-recovery.service';
+import { AuthRecoveryNotificationService } from './services/auth-recovery-notification.service';
 
 const RAW_OPTIONS_TOKEN = Symbol('__AUTH_RECOVERY_MODULE_RAW_OPTIONS_TOKEN__');
 
@@ -71,13 +73,14 @@ export function createAuthRecoveryImports(): DynamicModule['imports'] {
   return [ConfigModule.forFeature(authRecoveryDefaultConfig)];
 }
 
-export function createAuthRecoveryExports(): string[] {
+export function createAuthRecoveryExports() {
   return [
     AUTH_RECOVERY_MODULE_SETTINGS_TOKEN,
     AUTH_RECOVERY_MODULE_OTP_SERVICE_TOKEN,
     AUTH_RECOVERY_MODULE_EMAIL_SERVICE_TOKEN,
     AUTH_RECOVERY_MODULE_USER_LOOKUP_SERVICE_TOKEN,
     AUTH_RECOVERY_MODULE_USER_MUTATE_SERVICE_TOKEN,
+    AuthRecoveryService,
   ];
 }
 
@@ -87,6 +90,8 @@ export function createAuthRecoveryProviders(options: {
 }): Provider[] {
   return [
     ...(options.providers ?? []),
+    AuthRecoveryService,
+    AuthRecoveryNotificationService,
     createAuthRecoverySettingsProvider(options.overrides),
     createAuthRecoveryOtpServiceProvider(options.overrides),
     createAuthRecoveryEmailServiceProvider(options.overrides),

--- a/packages/nestjs-auth-recovery/src/auth-recovery.module.ts
+++ b/packages/nestjs-auth-recovery/src/auth-recovery.module.ts
@@ -10,15 +10,7 @@ import {
   createAuthRecoveryProviders,
 } from './auth-recovery.module-definition';
 
-import { AuthRecoveryService } from './services/auth-recovery.service';
-import { AuthRecoveryNotificationService } from './services/auth-recovery-notification.service';
-import { AuthRecoveryController } from './auth-recovery.controller';
-
-@Module({
-  providers: [AuthRecoveryService, AuthRecoveryNotificationService],
-  controllers: [AuthRecoveryController],
-  exports: [AuthRecoveryService],
-})
+@Module({})
 export class AuthRecoveryModule extends AuthRecoveryModuleClass {
   static register(options: AuthRecoveryOptions): DynamicModule {
     return super.register(options);

--- a/packages/nestjs-auth-refresh/src/auth-refresh.module-definition.ts
+++ b/packages/nestjs-auth-refresh/src/auth-refresh.module-definition.ts
@@ -25,6 +25,7 @@ import { AuthRefreshOptionsExtrasInterface } from './interfaces/auth-refresh-opt
 import { AuthRefreshSettingsInterface } from './interfaces/auth-refresh-settings.interface';
 import { AuthRefreshController } from './auth-refresh.controller';
 import { authRefreshDefaultConfig } from './config/auth-refresh-default.config';
+import { AuthRefreshStrategy } from './auth-refresh.strategy';
 
 const RAW_OPTIONS_TOKEN = Symbol('__AUTH_REFRESH_MODULE_RAW_OPTIONS_TOKEN__');
 
@@ -72,12 +73,13 @@ export function createAuthRefreshImports(): DynamicModule['imports'] {
   return [ConfigModule.forFeature(authRefreshDefaultConfig)];
 }
 
-export function createAuthRefreshExports(): string[] {
+export function createAuthRefreshExports() {
   return [
     AUTH_REFRESH_MODULE_SETTINGS_TOKEN,
     AUTH_REFRESH_MODULE_USER_LOOKUP_SERVICE_TOKEN,
     AUTH_REFRESH_MODULE_VERIFY_SERVICE_TOKEN,
     AUTH_REFRESH_MODULE_ISSUE_SERVICE_TOKEN,
+    AuthRefreshStrategy,
   ];
 }
 
@@ -87,6 +89,8 @@ export function createAuthRefreshProviders(options: {
 }): Provider[] {
   return [
     ...(options.providers ?? []),
+    AuthRefreshStrategy,
+    VerifyTokenService,
     IssueTokenService,
     createAuthRefreshOptionsProvider(options.overrides),
     createAuthRefreshVerifyTokenServiceProvider(options.overrides),

--- a/packages/nestjs-auth-refresh/src/auth-refresh.module.ts
+++ b/packages/nestjs-auth-refresh/src/auth-refresh.module.ts
@@ -1,8 +1,4 @@
 import { DynamicModule, Module } from '@nestjs/common';
-import {
-  IssueTokenService,
-  VerifyTokenService,
-} from '@concepta/nestjs-authentication';
 
 import {
   AuthRefreshAsyncOptions,
@@ -14,17 +10,10 @@ import {
   createAuthRefreshProviders,
 } from './auth-refresh.module-definition';
 
-import { AuthRefreshStrategy } from './auth-refresh.strategy';
-import { AuthRefreshController } from './auth-refresh.controller';
-
 /**
  * Auth Refresh module
  */
-@Module({
-  providers: [AuthRefreshStrategy, VerifyTokenService, IssueTokenService],
-  controllers: [AuthRefreshController],
-  exports: [AuthRefreshStrategy],
-})
+@Module({})
 export class AuthRefreshModule extends AuthRefreshModuleClass {
   static register(options: AuthRefreshOptions): DynamicModule {
     return super.register(options);

--- a/packages/nestjs-crud/src/crud.module-definition.ts
+++ b/packages/nestjs-crud/src/crud.module-definition.ts
@@ -11,6 +11,7 @@ import { CRUD_MODULE_SETTINGS_TOKEN } from './crud.constants';
 import { CrudOptionsExtrasInterface } from './interfaces/crud-options-extras.interface';
 import { CrudSettingsInterface } from './interfaces/crud-settings.interface';
 import { crudDefaultConfig } from './config/crud-default.config';
+import { CrudReflectionService } from './services/crud-reflection.service';
 
 const RAW_OPTIONS_TOKEN = Symbol('__CRUD_MODULE_RAW_OPTIONS_TOKEN__');
 
@@ -56,8 +57,8 @@ export function createCrudImports(
   }
 }
 
-export function createCrudExports(): string[] {
-  return [CRUD_MODULE_SETTINGS_TOKEN];
+export function createCrudExports() {
+  return [CRUD_MODULE_SETTINGS_TOKEN, CrudReflectionService];
 }
 
 export function createCrudProviders(options: {
@@ -66,6 +67,7 @@ export function createCrudProviders(options: {
 }): Provider[] {
   return [
     ...(options.providers ?? []),
+    CrudReflectionService,
     createCrudSettingsProvider(options.overrides),
   ];
 }

--- a/packages/nestjs-crud/src/crud.module.ts
+++ b/packages/nestjs-crud/src/crud.module.ts
@@ -1,5 +1,4 @@
 import { DynamicModule, Module } from '@nestjs/common';
-import { CrudReflectionService } from './services/crud-reflection.service';
 import {
   createCrudExports,
   createCrudImports,
@@ -9,10 +8,7 @@ import {
   CrudOptions,
 } from './crud.module-definition';
 
-@Module({
-  providers: [CrudReflectionService],
-  exports: [CrudReflectionService],
-})
+@Module({})
 export class CrudModule extends CrudModuleClass {
   static register(options: CrudOptions): DynamicModule {
     return super.register(options);

--- a/packages/nestjs-invitation/src/invitation.module-definition.ts
+++ b/packages/nestjs-invitation/src/invitation.module-definition.ts
@@ -28,6 +28,7 @@ import { InvitationAcceptanceService } from './services/invitation-acceptance.se
 import { InvitationSendService } from './services/invitation-send.service';
 import { InvitationRevocationService } from './services/invitation-revocation.service';
 import { invitationDefaultConfig } from './config/invitation-default.config';
+import { InvitationReattemptController } from './controllers/invitation-reattempt.controller';
 
 const RAW_OPTIONS_TOKEN = Symbol('__INVITATION_MODULE_RAW_OPTIONS_TOKEN__');
 
@@ -120,7 +121,11 @@ export function createInvitationControllers(
 ): DynamicModule['controllers'] {
   return overrides?.controllers !== undefined
     ? overrides.controllers
-    : [InvitationController, InvitationAcceptanceController];
+    : [
+        InvitationController,
+        InvitationAcceptanceController,
+        InvitationReattemptController,
+      ];
 }
 
 export function createInvitationSettingsProvider(

--- a/packages/nestjs-invitation/src/invitation.module.spec.ts
+++ b/packages/nestjs-invitation/src/invitation.module.spec.ts
@@ -21,6 +21,7 @@ import { InvitationUserMutateServiceInterface } from './interfaces/invitation-us
 import { InvitationServiceInterface } from './interfaces/invitation.service.interface';
 import { InvitationController } from './controllers/invitation.controller';
 import { InvitationAcceptanceController } from './controllers/invitation-acceptance.controller';
+import { InvitationReattemptController } from './controllers/invitation-reattempt.controller';
 import { InvitationService } from './services/invitation.service';
 import { InvitationSendService } from './services/invitation-send.service';
 import { InvitationAcceptanceService } from './services/invitation-acceptance.service';
@@ -49,6 +50,7 @@ describe(InvitationModule, () => {
   let invitationRevocationService: InvitationRevocationService;
   let invitationController: InvitationController;
   let invitationAcceptanceController: InvitationAcceptanceController;
+  let invitationReattemptController: InvitationReattemptController;
 
   const mockEmailService = mock<InvitationEmailServiceInterface>();
 
@@ -217,6 +219,11 @@ describe(InvitationModule, () => {
       testModule.get<InvitationAcceptanceController>(
         InvitationAcceptanceController,
       );
+
+    invitationReattemptController =
+      testModule.get<InvitationReattemptController>(
+        InvitationReattemptController,
+      );
   }
 
   function commonTests() {
@@ -237,6 +244,10 @@ describe(InvitationModule, () => {
     expect(invitationController).toBeInstanceOf(InvitationController);
     expect(invitationAcceptanceController).toBeInstanceOf(
       InvitationAcceptanceController,
+    );
+
+    expect(invitationReattemptController).toBeInstanceOf(
+      InvitationReattemptController,
     );
   }
 });

--- a/packages/nestjs-invitation/src/invitation.module.ts
+++ b/packages/nestjs-invitation/src/invitation.module.ts
@@ -5,33 +5,11 @@ import {
   InvitationModuleClass,
   InvitationOptions,
 } from './invitation.module-definition';
-import { InvitationService } from './services/invitation.service';
-import { InvitationCrudService } from './services/invitation-crud.service';
-import { InvitationAcceptanceService } from './services/invitation-acceptance.service';
-import { InvitationSendService } from './services/invitation-send.service';
-import { InvitationRevocationService } from './services/invitation-revocation.service';
-import { InvitationController } from './controllers/invitation.controller';
-import { InvitationAcceptanceController } from './controllers/invitation-acceptance.controller';
-import { InvitationReattemptController } from './controllers/invitation-reattempt.controller';
 
 /**
  * Invitation module
  */
-@Module({
-  providers: [
-    InvitationService,
-    InvitationCrudService,
-    InvitationAcceptanceService,
-    InvitationSendService,
-    InvitationRevocationService,
-  ],
-  controllers: [
-    InvitationController,
-    InvitationAcceptanceController,
-    InvitationReattemptController,
-  ],
-  exports: [InvitationService],
-})
+@Module({})
 export class InvitationModule extends InvitationModuleClass {
   static register(options: InvitationOptions): DynamicModule {
     return super.register(options);

--- a/packages/nestjs-jwt/src/jwt.module-definition.ts
+++ b/packages/nestjs-jwt/src/jwt.module-definition.ts
@@ -68,11 +68,14 @@ export function createJwtImports(
   }
 }
 
-export function createJwtExports(): string[] {
+export function createJwtExports() {
   return [
     JWT_MODULE_SETTINGS_TOKEN,
     JWT_MODULE_JWT_ACCESS_SERVICE_TOKEN,
     JWT_MODULE_JWT_REFRESH_SERVICE_TOKEN,
+    JwtSignService,
+    JwtIssueService,
+    JwtVerifyService,
   ];
 }
 
@@ -82,6 +85,9 @@ export function createJwtProviders(options: {
 }): Provider[] {
   return [
     ...(options.providers ?? []),
+    JwtSignService,
+    JwtIssueService,
+    JwtVerifyService,
     createJwtSettingsProvider(options.overrides),
     createJwtServiceAccessTokenProvider(options.overrides),
     createJwtServiceRefreshTokenProvider(options.overrides),

--- a/packages/nestjs-jwt/src/jwt.module-definition.ts
+++ b/packages/nestjs-jwt/src/jwt.module-definition.ts
@@ -85,9 +85,6 @@ export function createJwtProviders(options: {
 }): Provider[] {
   return [
     ...(options.providers ?? []),
-    JwtSignService,
-    JwtIssueService,
-    JwtVerifyService,
     createJwtSettingsProvider(options.overrides),
     createJwtServiceAccessTokenProvider(options.overrides),
     createJwtServiceRefreshTokenProvider(options.overrides),

--- a/packages/nestjs-jwt/src/jwt.module.ts
+++ b/packages/nestjs-jwt/src/jwt.module.ts
@@ -1,8 +1,5 @@
 import { DynamicModule, Module } from '@nestjs/common';
 
-import { JwtIssueService } from './services/jwt-issue.service';
-import { JwtSignService } from './services/jwt-sign.service';
-import { JwtVerifyService } from './services/jwt-verify.service';
 import {
   JwtModuleClass,
   JwtOptions,
@@ -12,10 +9,7 @@ import {
   createJwtExports,
 } from './jwt.module-definition';
 
-@Module({
-  providers: [JwtSignService, JwtIssueService, JwtVerifyService],
-  exports: [JwtSignService, JwtIssueService, JwtVerifyService],
-})
+@Module({})
 export class JwtModule extends JwtModuleClass {
   static register(options: JwtOptions): DynamicModule {
     return super.register(options);

--- a/packages/nestjs-swagger-ui/src/swagger-ui.module-definition.ts
+++ b/packages/nestjs-swagger-ui/src/swagger-ui.module-definition.ts
@@ -15,6 +15,7 @@ import {
 } from './swagger-ui.constants';
 import { createDefaultDocumentBuilder } from './utils/create-default-document-builder';
 import { SwaggerUiOptionsExtrasInterface } from './interfaces/swagger-ui-options-extras.interface';
+import { SwaggerUiService } from './swagger-ui.service';
 
 const RAW_OPTIONS_TOKEN = Symbol('__SWAGGER_UI_MODULE_RAW_OPTIONS_TOKEN__');
 
@@ -50,17 +51,30 @@ function definitionTransform(
     ...definition,
     ...extras,
     imports: [ConfigModule.forFeature(swaggerUiDefaultConfig)],
-    providers: [
-      ...providers,
-      createSwaggerUiSettingsProvider(),
-      createSwaggerUiDocumentBuilderProvider(),
-    ],
-    exports: [
-      ConfigModule,
-      RAW_OPTIONS_TOKEN,
-      SWAGGER_UI_MODULE_SETTINGS_TOKEN,
-    ],
+    providers: createSwaggerUiProviders({ providers }),
+    exports: createSwaggerUiExports(),
   };
+}
+
+export function createSwaggerUiExports() {
+  return [
+    ConfigModule,
+    RAW_OPTIONS_TOKEN,
+    SWAGGER_UI_MODULE_SETTINGS_TOKEN,
+    SwaggerUiService,
+  ];
+}
+
+export function createSwaggerUiProviders(options: {
+  overrides?: SwaggerUiAsyncOptions;
+  providers?: Provider[];
+}): Provider[] {
+  return [
+    ...(options.providers ?? []),
+    SwaggerUiService,
+    createSwaggerUiSettingsProvider(),
+    createSwaggerUiDocumentBuilderProvider(),
+  ];
 }
 
 export function createSwaggerUiSettingsProvider(): Provider {

--- a/packages/nestjs-swagger-ui/src/swagger-ui.module.ts
+++ b/packages/nestjs-swagger-ui/src/swagger-ui.module.ts
@@ -1,15 +1,11 @@
 import { DynamicModule, Module } from '@nestjs/common';
-import { SwaggerUiService } from './swagger-ui.service';
 import {
   SwaggerUiAsyncOptions,
   SwaggerUiModuleClass,
   SwaggerUiOptions,
 } from './swagger-ui.module-definition';
 
-@Module({
-  providers: [SwaggerUiService],
-  exports: [SwaggerUiService],
-})
+@Module({})
 export class SwaggerUiModule extends SwaggerUiModuleClass {
   static register(options: SwaggerUiOptions): DynamicModule {
     return super.register(options);


### PR DESCRIPTION
In this PR, we're removing all properties from the `@Module()` decorator in our NestJS application. As we transition to using dynamic modules, we've noticed that NestJS merges both the static properties of `@Module()` and the dynamic configurations, leading to potential conflicts and unexpected behaviors.

To maintain clarity and avoid any unwanted merge of configurations, we're now solely relying on our module blueprint, `ConfigurableModuleBuilder`, to dictate the behavior and structure of our modules. Consequently, we've modified the `@Module` decorator to accept an empty object: `@Module({})`.

References:

https://github.com/nestjs/nest/blob/master/packages/core/scanner.ts#L239-L251

https://docs.nestjs.com/modules#:~:text=Note%20that%20the%20properties%20returned%20by%20the%20dynamic%20module%20extend%20(rather%20than%20override)%20the%20base%20module%20metadata%20defined%20in%20the%20%40Module()%20decorator

