### PR TITLE
fix: use nest di to provide applicationRef

### DIFF
--- a/packages/nestjs-logger/package.json
+++ b/packages/nestjs-logger/package.json
@@ -22,7 +22,8 @@
   "devDependencies": {
     "@nestjs/testing": "^9.0.0",
     "@sentry/types": "^6.13.3",
-    "jest-mock-extended": "^2.0.4"
+    "jest-mock-extended": "^2.0.4",
+    "supertest": "^6.3.3"
   },
   "peerDependencies": {
     "class-validator": "*",

--- a/packages/nestjs-logger/src/__fixture__/app.controller.fixture.ts
+++ b/packages/nestjs-logger/src/__fixture__/app.controller.fixture.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class AppControllerFixture {
+  @Get('throw')
+  throwError() {
+    throw new Error('Intentional Error');
+  }
+}

--- a/packages/nestjs-logger/src/__fixture__/app.module.fixture.ts
+++ b/packages/nestjs-logger/src/__fixture__/app.module.fixture.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { AppControllerFixture } from './app.controller.fixture';
+import { LoggerModule } from '../logger.module';
+
+@Module({
+  controllers: [AppControllerFixture],
+  imports: [LoggerModule.register({})],
+})
+export class AppModuleFixture {}

--- a/packages/nestjs-logger/src/logger-exception.filter.spec.ts
+++ b/packages/nestjs-logger/src/logger-exception.filter.spec.ts
@@ -1,40 +1,65 @@
-import { mock } from 'jest-mock-extended';
-
-import { ArgumentsHost, HttpServer } from '@nestjs/common';
-
+import { ArgumentsHost, INestApplication } from '@nestjs/common';
+import { TestingModule, Test } from '@nestjs/testing';
 import { LoggerExceptionFilter } from './logger-exception.filter';
 import { LoggerService } from './logger.service';
+import { mock } from 'jest-mock-extended';
+import { HttpAdapterHost } from '@nestjs/core';
+import { LoggerTransportService } from './logger-transport.service';
 
 describe('LoggerExceptionFilter', () => {
-  let httpServer: HttpServer;
+  let app: INestApplication;
   let loggerService: LoggerService;
-  let argumentsHost: ArgumentsHost;
   let loggerExceptionFilter: LoggerExceptionFilter;
-  let spyLoggerServiceException: jest.SpyInstance;
 
   beforeEach(async () => {
-    httpServer = mock<HttpServer>();
-    loggerService = mock<LoggerService>();
-    argumentsHost = mock<ArgumentsHost>();
-    spyLoggerServiceException = jest.spyOn(loggerService, 'exception');
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LoggerService,
+        LoggerExceptionFilter,
+        {
+          provide: LoggerTransportService,
+          useValue: {
+            addTransport: jest.fn(),
+            log: jest.fn(),
+          },
+        },
+        {
+          provide: HttpAdapterHost,
+          useValue: {
+            httpAdapter: {
+              isHeadersSent: jest.fn(),
+              reply: jest.fn(),
+              end: jest.fn(),
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    app = module.createNestApplication();
+    loggerService = module.get<LoggerService>(LoggerService);
+    loggerExceptionFilter = module.get<LoggerExceptionFilter>(
+      LoggerExceptionFilter,
+    );
+
+    await app.init();
   });
 
   describe('IsDefined', () => {
     it('was LoggerExceptionFilter defined', async () => {
-      expect(httpServer).toBeDefined();
       expect(loggerService).toBeDefined();
-      expect(argumentsHost).toBeDefined();
+      expect(loggerExceptionFilter).toBeDefined();
     });
   });
 
   it('LoggerExceptionFilter.catch', async () => {
-    loggerExceptionFilter = new LoggerExceptionFilter(
-      loggerService,
-      httpServer,
-    );
-    loggerExceptionFilter.catch(new Error(), argumentsHost);
+    const spyLoggerServiceException = jest.spyOn(loggerService, 'exception');
+    loggerExceptionFilter.catch(new Error(), mock<ArgumentsHost>());
 
-    expect(loggerExceptionFilter).toBeDefined();
     expect(spyLoggerServiceException).toBeCalledTimes(1);
+  });
+
+  afterEach(async () => {
+    await app.close();
   });
 });

--- a/packages/nestjs-logger/src/logger-exception.filter.ts
+++ b/packages/nestjs-logger/src/logger-exception.filter.ts
@@ -1,11 +1,5 @@
-import {
-  ArgumentsHost,
-  Catch,
-  HttpServer,
-  Inject,
-  Injectable,
-} from '@nestjs/common';
-import { BaseExceptionFilter, HttpAdapterHost } from '@nestjs/core';
+import { ArgumentsHost, Catch, Inject, Injectable } from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
 
 import { LoggerService } from './logger.service';
 
@@ -29,10 +23,8 @@ export class LoggerExceptionFilter extends BaseExceptionFilter {
   constructor(
     @Inject(LoggerService)
     private loggerService: LoggerService,
-    @Inject(HttpAdapterHost)
-    applicationRef?: HttpServer,
   ) {
-    super(applicationRef);
+    super();
   }
 
   /**


### PR DESCRIPTION
### Description
Fixes Issue #120 where using `@concepta/nestjs-logger` throws a TypeError due to an undefined applicationRef in LoggerExceptionFilter.

### Changes
Removed the HttpAdapterHost injection and applicationRef?: HttpServer parameter from the LoggerExceptionFilter constructor, now it just calls super().

https://github.com/conceptadev/rockets/pull/129/files#diff-16e67cbd96849b2d66993ef310fe997a094392bc210af8a5886cd8c2a952c34fR23-R27

### Why?
The initial setup tried injecting HttpAdapterHost to get applicationRef, but it wasn’t working out, causing the TypeError in Issue #120. By stripping this part from the constructor, we're keeping things simple and letting NestJS's Dependency Injection do its thing without stumbling into this error. This tweak should get rid of the applicationRef.isHeadersSent TypeError.

### References
https://github.com/nestjs/nest/issues/8076#issuecomment-926542597