### PR TITLE
ci: cancel superseded pull request runs

### DIFF
--- a/.github/workflows/ci-pr-test.yml
+++ b/.github/workflows/ci-pr-test.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: ['main']
 
+concurrency:
+  group: pr-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

New pushes currently leave superseded pull-request runs executing. Cancel older runs of each changed workflow for the same PR so runner time is spent on the latest commit. Other PRs and non-PR runs retain their existing behavior.

- `.github/workflows/ci-pr-test.yml`

## Validation

- YAML parsing and structural comparison passed: only `concurrency` changed.
- `git diff --no-index --check` found no whitespace errors.
- `actionlint -shellcheck= -pyflakes=` reports the same existing diagnostics before and after this patch; no new diagnostics.

Existing findings: the runner of "actions/cache@v3" action is too old to run on GitHub Actions. update the action's version to fix this issue; the runner of "actions/checkout@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue; the runner of "actions/setup-node@v2" action is too old to run on GitHub Actions. update the action's version to fix this issue.

Application suites were not run locally for this workflow-only patch. Keep this PR in draft until applicable CI completes. Live cancellation behavior remains to be checked by pushing again while a PR run is active; a `pull_request_target` workflow uses the base-branch definition until this change is merged.


## CI verification snapshot

All reported checks for commit `90a1b5d3a4ef774d055d70b34fb0a9bdbe56162a` have completed successfully or were intentionally skipped, as of 2026-09-11T16:04:49+00:00. No failing or pending checks were reported.
